### PR TITLE
updated notebook for benchmark q&a generation

### DIFF
--- a/financial_transcripts/preprocessing/generate_benchmark_qa.ipynb
+++ b/financial_transcripts/preprocessing/generate_benchmark_qa.ipynb
@@ -35,10 +35,53 @@
    "outputs": [],
    "source": [
     "from dotenv import dotenv_values\n",
+    "from azure.keyvault.secrets import SecretClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "import openai\n",
     "\n",
     "# specify the name of the .env file name \n",
     "env_name = \"../../.env\" # change to your own .env file name\n",
     "config = dotenv_values(env_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "keyvault was selected.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Remember to remove the key from your code when you're done, and never post it publicly. For production, use\n",
+    "secure methods to store and access your credentials. For more information, see \n",
+    "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-security?tabs=command-line%2Ccsharp#environment-variables-and-application-configuration\n",
+    "\"\"\"\n",
+    "\n",
+    "if config['KEYS_FROM'] == \"KEYVAULT\":\n",
+    "    print('keyvault was selected.')\n",
+    "    keyVaultName = config[\"KEY_VAULT_NAME\"]\n",
+    "    KVUri = f\"https://{keyVaultName}.vault.azure.net\"\n",
+    "\n",
+    "    credential = DefaultAzureCredential()\n",
+    "    client = SecretClient(vault_url=KVUri, credential=credential)\n",
+    "    openai.api_type = client.get_secret(\"OPENAI-API-TYPE\").value\n",
+    "    openai.api_key = client.get_secret(\"OPENAI-API-KEY\").value\n",
+    "    openai.api_base = client.get_secret(\"OPENAI-API-BASE\").value\n",
+    "    openai.api_version = client.get_secret(\"OPENAI-API-VERSION\").value\n",
+    "    \n",
+    "else:\n",
+    "    print('.env was selected.')\n",
+    "    openai.api_type = config[\"OPENAI_API_TYPE\"] \n",
+    "    openai.api_key = config[\"OPENAI_API_KEY\"]\n",
+    "    openai.api_base = config[\"OPENAI_API_BASE\"] \n",
+    "    openai.api_version = config[\"OPENAI_API_VERSION\"] "
    ]
   },
   {
@@ -50,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -265,7 +308,7 @@
        "[108 rows x 8 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +328,7 @@
        "\"Cosmos DB now supports PostgreSQL, making Azure the first cloud provider to offer a database service that supports both relational and NoSQL workloads. And, in Al, we are turning the world's most advanced models into platforms for customers. Earlier this month, we brought the power of Dall-E to Azure OpenAI service, helping customers like Mattel apply the breakthrough image generation model to commercial use cases for the first time. And Azure Machine Learning provides industry leading MLOps, helping organizations like 3M deploy, manage, and govern models. \""
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -299,12 +342,12 @@
    "metadata": {},
    "source": [
     "#### Prompt Template\n",
-    "##### Write a Prompt Tempalte. The prompt template should include all filter keys, so they can be referenced and input."
+    "##### Write a Prompt Template. The prompt template should include all filter keys, so they can be referenced and input."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,16 +420,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1214"
+       "1929"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -397,16 +440,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"And Azure AI is ushering in new, born-in-the cloud AI-first workloads, with the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI. We have great momentum across Azure OpenAI Service. More than 11,000 organizations across industries, including Ikea, Volvo Group, Zurich Insurance, as well as digital natives like Flipkart, Humane, Kahoot, Miro, Typeface, use the service. That's nearly 100 new customers added every day this quarter. Mercedes-Benz, for example, is bringing ChatGPT via Azure OpenAI to  That's nearly 100 new customers added every day this quarter. Mercedes-Benz, for example, is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States, making its in-car voice assistant more intuitive. And Moody's built its own internal copilot to improve productivity of its 14,000 employees. We are also partnering broadly to scale this next generation of AI to more customers. Snowflake, for example, will increase its Azure spend as it builds new integrations with Azure OpenAI. And, KPMG has announced a multi-billion- dollar commitment to our cloud and AI services to transform professional \""
+       "\"one question. Joe, can you please repeat your instructions? (Operator Direction.) KEITH WEISS, Morgan Stanley: Excellent. Thank you guys for taking the question and very nice end to a great fiscal year. Satya, you started out your comments talking about how every customer conversation has the customer asking you about utilizing generative AI technology and how fast they could utilize that generative AI technology. What's the answer? What do you tell them in terms of the pace with which that could get into the marketplace and your customers could start using it?  that could get into the marketplace and your customers could start using it? And then for Amy, how should investors think about just the fundamental gross margins behind these generative AI technologies? We understand there's going to be a lot of CapEx to ramp up underneath these, but what should we expect in terms of what the ultimate gross margin looks like underneath all these new generative AI solutions? Thank you. SATYA NADELLA: Thank you, Keith, for the question. The fundamental guidance and conversation that we have with customers is twofold. One is the easiest path to value or generative AI is to adopt certain solutions. For  guidance and conversation that we have with customers is twofold. One is the easiest path to value or generative AI is to adopt certain solutions. For example, GitHub Copilot, in some sense, it's sort of the no brainer to add productivity leverage for all of the software developers in any organization. Whether you're a bank, you're a retailer or you're a software company, it applies to everyone. That's probably one of the things that we are seeing very good even productivity data and great adoption. And then obviously the excitement that there is already around the M365 Copilot. First thing we sort of talked about is how we ourselves are deploying all these copilots across, whether it's Sales Copilot or M365 \""
       ]
      },
-     "execution_count": 61,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -417,19 +460,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MSFT 23 4 357 418\n"
+      "MSFT 23 4 29 12\n"
      ]
     }
    ],
    "source": [
-    "print(Ticker, Year, Quarter, Id, Id2)"
+    "print(Ticker, Year, Quarter, pagenum1, pagenum2)"
    ]
   },
   {
@@ -441,42 +484,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Question 1: What AI models are supported by Azure AI for MSFT FY23 Q4?\n",
-      "Answer 1: Azure AI supports the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI.\n",
+      "Question 1: What are some AI-powered solutions that Microsoft is currently offering to customers?\n",
+      "Answer 1: Microsoft is offering GitHub Copilot, M365 Copilot, and Sales Copilot to customers.\n",
       "\n",
-      "Question 2: How many new customers were added to Azure OpenAI service during MSFT FY23 Q4?\n",
-      "Answer 2: Nearly 100 new customers were added every day during MSFT FY23 Q4, including organizations across industries such as Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface.\n",
+      "Question 2: Are customers interested in using generative AI technology and how fast do they want to utilize it?\n",
+      "Answer 2: Yes, customers are interested in utilizing generative AI technology. However, no specific timeframe was mentioned in the given text.\n",
       "\n",
-      "Question 3: Which organization is bringing ChatGPT via Azure OpenAI to over 900,000 vehicles in the United States for MSFT FY23 Q4?\n",
-      "Answer 3: Mercedes-Benz is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States during MSFT FY23 Q4.\n",
+      "Question 3: What AI-powered collaborative articles are driving the most traffic to LinkedIn?\n",
+      "Answer 3: LinkedIn's AI-powered collaborative articles are the fastest-growing traffic driver to the platform, but no specific type or topic was mentioned.\n",
       "\n",
-      "Question 4: Who built their own internal copilot to improve productivity of its 14,000 employees in MSFT FY23 Q4?\n",
-      "Answer 4: Moody's built its own internal copilot to improve productivity of its 14,000 employees during MSFT FY23 Q4.\n",
+      "Question 4: How is LinkedIn using AI to ensure trust and authenticity amongst its members?\n",
+      "Answer 4: LinkedIn is helping its members verify their identities and places of work through integration with Microsoft Entra, as well as CLEAR and Hyperverge. \n",
       "\n",
-      "Question 5: What is the scale of KPMG's commitment to Microsoft's cloud and AI services for transforming professional services in MSFT FY23 Q4?\n",
-      "Answer 5: KPMG announced a multi-billion-dollar commitment to Microsoft's cloud and AI services for transforming professional services during MSFT FY23 Q4, but the exact scale is not mentioned in the given text.\n",
+      "Question 5: What are some new AI-powered features that Bing introduced this quarter?\n",
+      "Answer 5: Bing introduced multimodal capabilities with visual search in Bing Chat and Bing Chat Enterprise, which offers commercial data protection.\n",
       "\n",
-      "Question 6: What is the status of Security Copilot and some of the Dynamics workloads for MSFT FY23 Q4?\n",
-      "Answer 6: We still have to get our Security Copilot and some of the Dynamics workloads priced and released during MSFT FY23 Q4, according to the given text.\n",
+      "Question 6: Is Bing the default search experience for OpenAI's ChatGPT?\n",
+      "Answer 6: Yes, Bing is the default search experience for OpenAI's ChatGPT.\n",
       "\n",
-      "Question 7: What is the platform effect for extensibility of copilots for MSFT FY23 Q4?\n",
-      "Answer 7: The platform effect for extensibility of copilots is really all about the extensibility of the copilots and how they pull along both core Azure and Al Azure for MSFT FY23 Q4.\n",
+      "Question 7: How many members have verified their identities or places of work on LinkedIn?\n",
+      "Answer 7: More than 7 million members have verified their identities or places of work on LinkedIn.\n",
       "\n",
-      "Question 8: How important is Azure for building AI products for MSFT FY23 Q4, according to the given text?\n",
-      "Answer 8: Azure is important for building AI products because it's not just the Al solution services that you need to build an app. And so, it's less about Microsoft 365 pulling it along or any one copilot. It's that when you're building these, it requires data, and it requires the Al services. You'll see them pull both core Azure and Al Azure along with them during MSFT FY23 Q4.\n",
+      "Question 8: What is the main focus of Microsoft's generative AI technology strategy?\n",
+      "Answer 8: Microsoft's generative AI technology strategy focuses on offering solutions that provide the easiest path to value for customers.\n",
       "\n",
-      "Question 9: Which organizations mentioned in the given text use Azure OpenAI service during MSFT FY23 Q4?\n",
-      "Answer 9: Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface are some of the organizations mentioned in the given text that use Azure OpenAI service during MSFT FY23 Q4.\n",
+      "Question 9: What is the main goal of LinkedIn's AI-powered collaborative articles?\n",
+      "Answer 9: The main goal of LinkedIn's AI-powered collaborative articles is to drive traffic to the platform.\n",
       "\n",
-      "Question 10: Is there any information on the revenue generated by AI-first workloads in MSFT FY23 Q4?\n",
-      "Answer 10: N/A, there is no information on the revenue generated by AI-first workloads in the given text for MSFT FY23 Q4.\n"
+      "Question 10: How does Bing's new AI-powered features benefit businesses?\n",
+      "Answer 10: Bing Chat Enterprise offers commercial data protection, which is an easy on-ramp for organizations looking to get the benefit of this next generation AI solution.\n"
      ]
     }
    ],
@@ -485,9 +528,9 @@
     "from openai import AzureOpenAI\n",
     "\n",
     "client = AzureOpenAI(\n",
-    "  api_key = config[\"OPENAI_API_KEY\"],  \n",
-    "  api_version = config[\"OPENAI_API_VERSION\"],\n",
-    "  azure_endpoint = config[\"OPENAI_API_BASE\"]\n",
+    "  api_key = openai.api_key,  \n",
+    "  api_version = openai.api_version,\n",
+    "  azure_endpoint = openai.api_base\n",
     ")\n",
     "\n",
     "response = client.chat.completions.create(\n",
@@ -508,42 +551,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Question 1: What AI models are supported by Azure AI for MSFT FY23 Q4?\n",
-      "Answer 1: Azure AI supports the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI.\n",
+      "Question 1: What are some AI-powered solutions that Microsoft is currently offering to customers?\n",
+      "Answer 1: Microsoft is offering GitHub Copilot, M365 Copilot, and Sales Copilot to customers.\n",
       "\n",
-      "Question 2: How many new customers were added to Azure OpenAI service during MSFT FY23 Q4?\n",
-      "Answer 2: Nearly 100 new customers were added every day during MSFT FY23 Q4, including organizations across industries such as Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface.\n",
+      "Question 2: Are customers interested in using generative AI technology and how fast do they want to utilize it?\n",
+      "Answer 2: Yes, customers are interested in utilizing generative AI technology. However, no specific timeframe was mentioned in the given text.\n",
       "\n",
-      "Question 3: Which organization is bringing ChatGPT via Azure OpenAI to over 900,000 vehicles in the United States for MSFT FY23 Q4?\n",
-      "Answer 3: Mercedes-Benz is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States during MSFT FY23 Q4.\n",
+      "Question 3: What AI-powered collaborative articles are driving the most traffic to LinkedIn?\n",
+      "Answer 3: LinkedIn's AI-powered collaborative articles are the fastest-growing traffic driver to the platform, but no specific type or topic was mentioned.\n",
       "\n",
-      "Question 4: Who built their own internal copilot to improve productivity of its 14,000 employees in MSFT FY23 Q4?\n",
-      "Answer 4: Moody's built its own internal copilot to improve productivity of its 14,000 employees during MSFT FY23 Q4.\n",
+      "Question 4: How is LinkedIn using AI to ensure trust and authenticity amongst its members?\n",
+      "Answer 4: LinkedIn is helping its members verify their identities and places of work through integration with Microsoft Entra, as well as CLEAR and Hyperverge. \n",
       "\n",
-      "Question 5: What is the scale of KPMG's commitment to Microsoft's cloud and AI services for transforming professional services in MSFT FY23 Q4?\n",
-      "Answer 5: KPMG announced a multi-billion-dollar commitment to Microsoft's cloud and AI services for transforming professional services during MSFT FY23 Q4, but the exact scale is not mentioned in the given text.\n",
+      "Question 5: What are some new AI-powered features that Bing introduced this quarter?\n",
+      "Answer 5: Bing introduced multimodal capabilities with visual search in Bing Chat and Bing Chat Enterprise, which offers commercial data protection.\n",
       "\n",
-      "Question 6: What is the status of Security Copilot and some of the Dynamics workloads for MSFT FY23 Q4?\n",
-      "Answer 6: We still have to get our Security Copilot and some of the Dynamics workloads priced and released during MSFT FY23 Q4, according to the given text.\n",
+      "Question 6: Is Bing the default search experience for OpenAI's ChatGPT?\n",
+      "Answer 6: Yes, Bing is the default search experience for OpenAI's ChatGPT.\n",
       "\n",
-      "Question 7: What is the platform effect for extensibility of copilots for MSFT FY23 Q4?\n",
-      "Answer 7: The platform effect for extensibility of copilots is really all about the extensibility of the copilots and how they pull along both core Azure and Al Azure for MSFT FY23 Q4.\n",
+      "Question 7: How many members have verified their identities or places of work on LinkedIn?\n",
+      "Answer 7: More than 7 million members have verified their identities or places of work on LinkedIn.\n",
       "\n",
-      "Question 8: How important is Azure for building AI products for MSFT FY23 Q4, according to the given text?\n",
-      "Answer 8: Azure is important for building AI products because it's not just the Al solution services that you need to build an app. And so, it's less about Microsoft 365 pulling it along or any one copilot. It's that when you're building these, it requires data, and it requires the Al services. You'll see them pull both core Azure and Al Azure along with them during MSFT FY23 Q4.\n",
+      "Question 8: What is the main focus of Microsoft's generative AI technology strategy?\n",
+      "Answer 8: Microsoft's generative AI technology strategy focuses on offering solutions that provide the easiest path to value for customers.\n",
       "\n",
-      "Question 9: Which organizations mentioned in the given text use Azure OpenAI service during MSFT FY23 Q4?\n",
-      "Answer 9: Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface are some of the organizations mentioned in the given text that use Azure OpenAI service during MSFT FY23 Q4.\n",
+      "Question 9: What is the main goal of LinkedIn's AI-powered collaborative articles?\n",
+      "Answer 9: The main goal of LinkedIn's AI-powered collaborative articles is to drive traffic to the platform.\n",
       "\n",
-      "Question 10: Is there any information on the revenue generated by AI-first workloads in MSFT FY23 Q4?\n",
-      "Answer 10: N/A, there is no information on the revenue generated by AI-first workloads in the given text for MSFT FY23 Q4.\n"
+      "Question 10: How does Bing's new AI-powered features benefit businesses?\n",
+      "Answer 10: Bing Chat Enterprise offers commercial data protection, which is an easy on-ramp for organizations looking to get the benefit of this next generation AI solution.\n"
      ]
     }
    ],
@@ -553,45 +596,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"Hyperverge. Now, on to search, advertising, and news. While it's early in our journey, we are reshaping daily search and web habits with our Copilot for the web. This quarter, we introduced new AI-powered features, including multimodal capabilities with visual search in Bing Chat. We're expanding to businesses, with Bing Chat Enterprise, which offers commercial data protection, providing an easy on-ramp for any organization looking to get the benefit of this next generation of AI today. Bing is also the default search experience for OpenAl's ChatGPT, bringing \""
+       "['one question.',\n",
+       " 'Joe, can you please repeat your instructions?',\n",
+       " '(Operator Direction.) KEITH WEISS, Morgan Stanley: Excellent.',\n",
+       " 'Thank you guys for taking the question and very nice end to a great fiscal year.',\n",
+       " 'Satya, you started out your comments talking about how every customer conversation has the customer asking you about utilizing generative AI technology and how fast they could utilize that generative AI technology.',\n",
+       " \"What's the answer?\",\n",
+       " 'What do you tell them in terms of the pace with which that could get into the marketplace and your customers could start using it?',\n",
+       " ' that could get into the marketplace and your customers could start using it?',\n",
+       " 'And then for Amy, how should investors think about just the fundamental gross margins behind these generative AI technologies?',\n",
+       " \"We understand there's going to be a lot of CapEx to ramp up underneath these, but what should we expect in terms of what the ultimate gross margin looks like underneath all these new generative AI solutions?\",\n",
+       " 'Thank you.',\n",
+       " 'SATYA NADELLA: Thank you, Keith, for the question.',\n",
+       " 'The fundamental guidance and conversation that we have with customers is twofold.',\n",
+       " 'One is the easiest path to value or generative AI is to adopt certain solutions.',\n",
+       " 'For  guidance and conversation that we have with customers is twofold.',\n",
+       " 'One is the easiest path to value or generative AI is to adopt certain solutions.',\n",
+       " \"For example, GitHub Copilot, in some sense, it's sort of the no brainer to add productivity leverage for all of the software developers in any organization.\",\n",
+       " \"Whether you're a bank, you're a retailer or you're a software company, it applies to everyone.\",\n",
+       " \"That's probably one of the things that we are seeing very good even productivity data and great adoption.\",\n",
+       " 'And then obviously the excitement that there is already around the M365 Copilot.',\n",
+       " \"First thing we sort of talked about is how we ourselves are deploying all these copilots across, whether it's Sales Copilot or M365 \"]"
       ]
      },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df[(df['Quarter']==Quarter) & (df['Year']==Year) & (df['Id']==Id)].Chunk.values[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[\"And Azure AI is ushering in new, born-in-the cloud AI-first workloads, with the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI.\",\n",
-       " 'We have great momentum across Azure OpenAI Service.',\n",
-       " 'More than 11,000 organizations across industries, including Ikea, Volvo Group, Zurich Insurance, as well as digital natives like Flipkart, Humane, Kahoot, Miro, Typeface, use the service.',\n",
-       " \"That's nearly 100 new customers added every day this quarter.\",\n",
-       " \"Mercedes-Benz, for example, is bringing ChatGPT via Azure OpenAI to  That's nearly 100 new customers added every day this quarter.\",\n",
-       " 'Mercedes-Benz, for example, is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States, making its in-car voice assistant more intuitive.',\n",
-       " \"And Moody's built its own internal copilot to improve productivity of its 14,000 employees.\",\n",
-       " 'We are also partnering broadly to scale this next generation of AI to more customers.',\n",
-       " 'Snowflake, for example, will increase its Azure spend as it builds new integrations with Azure OpenAI.',\n",
-       " 'And, KPMG has announced a multi-billion- dollar commitment to our cloud and AI services to transform professional ']"
-      ]
-     },
-     "execution_count": 78,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -605,27 +639,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['course, be able to sell it and then recognize revenue.',\n",
-       " 'And that is why I continue to say that I am just as excited as everyone else about this, and it should be more H2 weighted.',\n",
-       " \"And we've, I think, given you some sizing opportunities and I think I would use all that.\",\n",
-       " 'But I do think this is really about pacing.',\n",
-       " \"And, of course, we've still got to get our Security Copilot and some of the Dynamics workloads priced and released, and we'll continue to work toward that.\",\n",
-       " \"And, of course, I think one of the things that people often, I think, overlook is, and Satya mentioned it briefly, when you go back to the pull along Azure, I think in many ways, lots of these AI products pull along Azure  is, and Satya mentioned it briefly, when you go back to the pull along Azure, I think in many ways, lots of these AI products pull along Azure because it's not just the Al solution services that you need to build an app.\",\n",
-       " \"And so, it's less about Microsoft 365 pulling it along or any one copilot.\",\n",
-       " \"It's that when you're building these, it requires data, and it requires the Al services.\",\n",
-       " \"You'll see them pull both core Azure and Al Azure along with them.\",\n",
-       " \"And I think that's an important nuance as well.\",\n",
-       " 'SATYA NADELLA: Yeah, and if I could just add to what Amy said, the platform effect here is really all about the extensibility of the copilots.',\n",
-       " 'You see that today when people build applications in Teams that are built on ']"
+       "['fourth consecutive quarter.',\n",
+       " 'We continue to use AI to help our members and customers connect to opportunities and tap into experiences of experts on the platform.',\n",
+       " \"Our AI- powered collaborative articles are now the fastest-growing traffic driver to LinkedIn. And finally, we're helping LinkedIn stay trusted and authentic.\",\n",
+       " 'More than 7 million members have verified who they are or where they work, many using new integrations with Microsoft Entra, as well as CLEAR and Hyperverge.',\n",
+       " 'Now, on to search, advertising, and news.',\n",
+       " ' Hyperverge.',\n",
+       " 'Now, on to search, advertising, and news.',\n",
+       " \"While it's early in our journey, we are reshaping daily search and web habits with our Copilot for the web.\",\n",
+       " 'This quarter, we introduced new AI-powered features, including multimodal capabilities with visual search in Bing Chat.',\n",
+       " \"We're expanding to businesses, with Bing Chat Enterprise, which offers commercial data protection, providing an easy on-ramp for any organization looking to get the benefit of this next generation of AI today.\",\n",
+       " \"Bing is also the default search experience for OpenAl's ChatGPT, bringing \"]"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,26 +666,6 @@
    "source": [
     "retrieved_sentences2=_pattern.split(chunk2)\n",
     "retrieved_sentences2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\"Question 1: What AI models are supported by Azure AI for MSFT FY23 Q4?\\nAnswer 1: Azure AI supports the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI.\\n\\nQuestion 2: How many new customers were added to Azure OpenAI service during MSFT FY23 Q4?\\nAnswer 2: Nearly 100 new customers were added every day during MSFT FY23 Q4, including organizations across industries such as Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface.\\n\\nQuestion 3: Which organization is bringing ChatGPT via Azure OpenAI to over 900,000 vehicles in the United States for MSFT FY23 Q4?\\nAnswer 3: Mercedes-Benz is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States during MSFT FY23 Q4.\\n\\nQuestion 4: Who built their own internal copilot to improve productivity of its 14,000 employees in MSFT FY23 Q4?\\nAnswer 4: Moody's built its own internal copilot to improve productivity of its 14,000 employees during MSFT FY23 Q4.\\n\\nQuestion 5: What is the scale of KPMG's commitment to Microsoft's cloud and AI services for transforming professional services in MSFT FY23 Q4?\\nAnswer 5: KPMG announced a multi-billion-dollar commitment to Microsoft's cloud and AI services for transforming professional services during MSFT FY23 Q4, but the exact scale is not mentioned in the given text.\\n\\nQuestion 6: What is the status of Security Copilot and some of the Dynamics workloads for MSFT FY23 Q4?\\nAnswer 6: We still have to get our Security Copilot and some of the Dynamics workloads priced and released during MSFT FY23 Q4, according to the given text.\\n\\nQuestion 7: What is the platform effect for extensibility of copilots for MSFT FY23 Q4?\\nAnswer 7: The platform effect for extensibility of copilots is really all about the extensibility of the copilots and how they pull along both core Azure and Al Azure for MSFT FY23 Q4.\\n\\nQuestion 8: How important is Azure for building AI products for MSFT FY23 Q4, according to the given text?\\nAnswer 8: Azure is important for building AI products because it's not just the Al solution services that you need to build an app. And so, it's less about Microsoft 365 pulling it along or any one copilot. It's that when you're building these, it requires data, and it requires the Al services. You'll see them pull both core Azure and Al Azure along with them during MSFT FY23 Q4.\\n\\nQuestion 9: Which organizations mentioned in the given text use Azure OpenAI service during MSFT FY23 Q4?\\nAnswer 9: Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface are some of the organizations mentioned in the given text that use Azure OpenAI service during MSFT FY23 Q4.\\n\\nQuestion 10: Is there any information on the revenue generated by AI-first workloads in MSFT FY23 Q4?\\nAnswer 10: N/A, there is no information on the revenue generated by AI-first workloads in the given text for MSFT FY23 Q4.\""
-      ]
-     },
-     "execution_count": 83,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response.choices[0].message.content"
    ]
   },
   {
@@ -673,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,45 +704,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[{'chat_history': '[]',\n",
-       "  'question': 'What AI models are supported by Azure AI for MSFT FY23 Q4?',\n",
-       "  'answer': \"Azure AI supports the best selection of frontier and open models, including Meta's recent announcement supporting Llama on Azure and Windows, as well as OpenAI.\"},\n",
+       "  'question': 'What are some AI-powered solutions that Microsoft is currently offering to customers?',\n",
+       "  'answer': 'Microsoft is offering GitHub Copilot, M365 Copilot, and Sales Copilot to customers.'},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'How many new customers were added to Azure OpenAI service during MSFT FY23 Q4?',\n",
-       "  'answer': 'Nearly 100 new customers were added every day during MSFT FY23 Q4, including organizations across industries such as Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface.'},\n",
+       "  'question': 'Are customers interested in using generative AI technology and how fast do they want to utilize it?',\n",
+       "  'answer': 'Yes, customers are interested in utilizing generative AI technology. However, no specific timeframe was mentioned in the given text.'},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'Which organization is bringing ChatGPT via Azure OpenAI to over 900,000 vehicles in the United States for MSFT FY23 Q4?',\n",
-       "  'answer': 'Mercedes-Benz is bringing ChatGPT via Azure OpenAI to more than 900,000 vehicles in the United States during MSFT FY23 Q4.'},\n",
+       "  'question': 'What AI-powered collaborative articles are driving the most traffic to LinkedIn?',\n",
+       "  'answer': \"LinkedIn's AI-powered collaborative articles are the fastest-growing traffic driver to the platform, but no specific type or topic was mentioned.\"},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'Who built their own internal copilot to improve productivity of its 14,000 employees in MSFT FY23 Q4?',\n",
-       "  'answer': \"Moody's built its own internal copilot to improve productivity of its 14,000 employees during MSFT FY23 Q4.\"},\n",
+       "  'question': 'How is LinkedIn using AI to ensure trust and authenticity amongst its members?',\n",
+       "  'answer': 'LinkedIn is helping its members verify their identities and places of work through integration with Microsoft Entra, as well as CLEAR and Hyperverge.'},\n",
        " {'chat_history': '[]',\n",
-       "  'question': \"What is the scale of KPMG's commitment to Microsoft's cloud and AI services for transforming professional services in MSFT FY23 Q4?\",\n",
-       "  'answer': \"KPMG announced a multi-billion-dollar commitment to Microsoft's cloud and AI services for transforming professional services during MSFT FY23 Q4, but the exact scale is not mentioned in the given text.\"},\n",
+       "  'question': 'What are some new AI-powered features that Bing introduced this quarter?',\n",
+       "  'answer': 'Bing introduced multimodal capabilities with visual search in Bing Chat and Bing Chat Enterprise, which offers commercial data protection.'},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'What is the status of Security Copilot and some of the Dynamics workloads for MSFT FY23 Q4?',\n",
-       "  'answer': 'We still have to get our Security Copilot and some of the Dynamics workloads priced and released during MSFT FY23 Q4, according to the given text.'},\n",
+       "  'question': \"Is Bing the default search experience for OpenAI's ChatGPT?\",\n",
+       "  'answer': \"Yes, Bing is the default search experience for OpenAI's ChatGPT.\"},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'What is the platform effect for extensibility of copilots for MSFT FY23 Q4?',\n",
-       "  'answer': 'The platform effect for extensibility of copilots is really all about the extensibility of the copilots and how they pull along both core Azure and Al Azure for MSFT FY23 Q4.'},\n",
+       "  'question': 'How many members have verified their identities or places of work on LinkedIn?',\n",
+       "  'answer': 'More than 7 million members have verified their identities or places of work on LinkedIn.'},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'How important is Azure for building AI products for MSFT FY23 Q4, according to the given text?',\n",
-       "  'answer': \"Azure is important for building AI products because it's not just the Al solution services that you need to build an app. And so, it's less about Microsoft 365 pulling it along or any one copilot. It's that when you're building these, it requires data, and it requires the Al services. You'll see them pull both core Azure and Al Azure along with them during MSFT FY23 Q4.\"},\n",
+       "  'question': \"What is the main focus of Microsoft's generative AI technology strategy?\",\n",
+       "  'answer': \"Microsoft's generative AI technology strategy focuses on offering solutions that provide the easiest path to value for customers.\"},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'Which organizations mentioned in the given text use Azure OpenAI service during MSFT FY23 Q4?',\n",
-       "  'answer': 'Ikea, Volvo Group, Zurich Insurance, Flipkart, Humane, Kahoot, Miro, and Typeface are some of the organizations mentioned in the given text that use Azure OpenAI service during MSFT FY23 Q4.'},\n",
+       "  'question': \"What is the main goal of LinkedIn's AI-powered collaborative articles?\",\n",
+       "  'answer': \"The main goal of LinkedIn's AI-powered collaborative articles is to drive traffic to the platform.\"},\n",
        " {'chat_history': '[]',\n",
-       "  'question': 'Is there any information on the revenue generated by AI-first workloads in MSFT FY23 Q4?',\n",
-       "  'answer': 'N/A, there is no information on the revenue generated by AI-first workloads in the given text for MSFT FY23 Q4.'}]"
+       "  'question': \"How does Bing's new AI-powered features benefit businesses?\",\n",
+       "  'answer': 'Bing Chat Enterprise offers commercial data protection, which is an easy on-ramp for organizations looking to get the benefit of this next generation AI solution.'}]"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -740,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Added a notebook `generate_benchmark_qa.ipynb` to preprocessing for generation a number of questions and answers based on text in chunks. This notebook works with more recent version of Azure openai 1.6.1. It does not require additional frameworks such as langchain, to derisk the langchain update intricacies. It should work with previous version of Azure openai (<1.0.0) also, that was used for other purposes in this repo. 

There is a prompt template presented that allows using filter parameters. and context texts based on chunks of data. It can be further iterated. Note: Azure OpenAI function call is deprecated in more recent versions, and we want to use tools feature once we have a newer version deployed. (I tested tools with 12-01-2023 preview version, and it doesn't seem to work. We can revisit this later.)

Please run the notebook, and check that each cell works. The notebook shows 10 questions, but more can be generated. Experimentation might be required for further refinement. This is extension of the notebook in rag-e2e-samples, and parsing question/answers and saving to csv is added. Here we also use pagenumber in the filters to concatenate chunks and use them as context (in other case chunks are used directly).